### PR TITLE
Feature/eglot

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "copilot-el": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1703439558,
+        "narHash": "sha256-Tb0UWFBlqELLtKpA6tK1g+B0AqHDBRMVJjGPQQMpw7M=",
+        "owner": "zerolfx",
+        "repo": "copilot.el",
+        "rev": "653fe7b12990b5b7a050971bed4579022ce4b4f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zerolfx",
+        "repo": "copilot.el",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -56,9 +72,27 @@
     },
     "root": {
       "inputs": {
+        "copilot-el": "copilot-el",
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "scala-ts-mode": "scala-ts-mode"
+      }
+    },
+    "scala-ts-mode": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699361927,
+        "narHash": "sha256-uV0OYjA8qwJerPuWewkINoeHrjmyUTU68Mn5tYHWyb0=",
+        "owner": "KaranAhlawat",
+        "repo": "scala-ts-mode",
+        "rev": "cbfab189842ce564d9514f1b65a72b0af0d51438",
+        "type": "github"
+      },
+      "original": {
+        "owner": "KaranAhlawat",
+        "repo": "scala-ts-mode",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,14 @@
     # Home Manager is a tool that helps you manage your dotfiles
     home-manager.url = "github:nix-community/home-manager";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    copilot-el = {
+      url = "github:zerolfx/copilot.el";
+      flake = false;
+    };
+    scala-ts-mode = {
+      url = "github:KaranAhlawat/scala-ts-mode";
+      flake = false;
+    };
   };
 
   outputs = {

--- a/home/common/programs/emacs.nix
+++ b/home/common/programs/emacs.nix
@@ -18,6 +18,7 @@ in
 {
   programs.emacs = {
     enable = true;
+
     extraPackages = epkgs:
       with epkgs; [
         # Core packages
@@ -35,8 +36,6 @@ in
         all-the-icons-ivy-rich # More friendly display transformer for ivy
         dired-single # Reuse the dired buffer
         direnv # Environment switcher for Emacs
-        docker # Docker integration
-        dockerfile-mode # Major mode for editing Dockerfiles
         editorconfig # EditorConfig Emacs Plugin
         eldoc # Show function arglist or variable docstring in echo area
         emojify # Display emojis in Emacs
@@ -58,11 +57,6 @@ in
         org-roam-ui # A graphical user interface for org-roam
         pretty-mode # Redisplay parts of the buffer as pretty symbols
         projectile # Project Interaction Library for Emacs
-        # protobuf-mode # Major mode for editing protocol buffers
-        # simple-httpd # A simple HTTP server
-        # websocket # WebSocket client and server
-        web-mode # Major mode for editing web templates
-        # writegood-mode # A minor mode to aid in finding common writing problems
 
         # Terminal
         vterm # Fully-featured terminal emulator
@@ -73,14 +67,6 @@ in
 
         # Language Server
         dap-mode # Debug Adapter Protocol mode
-        # ccls # C/C++/ObjC language server
-        helm-lsp # Helm UI for the Language Server Protocol
-        lsp-java # Java
-        lsp-metals # Scala language server
-        lsp-treemacs # Treemacs integration f
-        lsp-tailwindcss # Tailwind CSS support for lsp-mode
-        lsp-mode # An implementation of the Language Server Protocol
-        lsp-ui # UI integrations for lsp-mode
 
         # Programming language packages.
         company # Modular text completion framework
@@ -97,25 +83,18 @@ in
         yasnippet # Template system for Emacs
         clojure-mode # Major mode for editing clojure files
         cider # Extends clojure-mode with superpowers
+        web-mode # Major mode for editing web templates
 
         # User interface packages.
         counsel # Various completion functions using Ivy
       ];
     extraConfig = ''
-      ;; General Settings
-      (defun nix-path (exeFile &rest joins)
-        "It returns the path to the /nix/store of EXEFILE and joins JOINS together into a string."
-        (let* ((target (string-trim (executable-find exeFile)))
-        (path (string-trim (shell-command-to-string (format "nix-store -q %s" target)))))
-          (string-join (cons path joins))))
-
       (setq inhibit-startup-message t) ; Disable startup message
       (menu-bar-mode -1) ; Disable the menu bar
       (tool-bar-mode -1) ; Disable the toolbar
       (scroll-bar-mode -1) ; Disable the scroll bar
       (setq-default indent-tabs-mode nil) ; Use spaces instead of tabs
 
-      ;; Enable relative line numbers
       (setq display-line-numbers-type 'default)
       (global-display-line-numbers-mode t)
 
@@ -155,50 +134,7 @@ in
         ;; Org Keybindings
         "oa" 'org-agenda
         "oc" 'org-capture
-
-        ;; LSP Keybindings
-        "lws" 'lsp-ui-sideline-mode
-        "lwd" 'lsp-ui-doc-mode
-        "lwr" 'lsp-ui-peek-find-references
-        "lwf" 'lsp-ui-peek-find-definitions
-        "lwa" 'lsp-ui-peek-find-implementation
-        "lwh" 'lsp-ui-doc-glance
-        "lwe" 'lsp-treemacs-errors-list
-        "lxf" 'xml-pretty-print
-        "lf" 'lsp-format-buffer
-        "lr" 'lsp-rename
-        "lR" 'lsp-workspace-restart
-        "la" 'lsp-execute-code-action
-        "ld" 'lsp-describe-thing-at-point
-        "lgt" 'lsp-goto-type-definition
-        "lgi" 'lsp-goto-implementation
-        "lsh" 'lsp-symbol-highlight
-        "lwa" 'lsp-workspace-folders-add
-        "lwr" 'lsp-workspace-folders-remove
-        "lws" 'lsp-workspace-folders-switch
-
-        ;; Java Keybindings
-        "jo" 'lsp-java-organize-imports
-        "jbp" 'lsp-java-build-project
-        "jupc" 'lsp-java-update-project-configuration
-        "jan" 'lsp-java-actionable-notifications
-        "juus" 'lsp-java-update-user-settings
-        "jus" 'lsp-java-update-server
-        "jgt" 'lsp-java-generate-to-string
-        "jgeh" 'lsp-java-generate-equals-and-hash-code
-        "jgo" 'lsp-java-generate-overrides
-        "jggs" 'lsp-java-generate-getters-and-setters
-        "jth" 'lsp-java-type-hierarchy
-        "jec" 'lsp-java-extract-to-constant
-        "jaum" 'lsp-java-add-unimplemented-methods
-        "jcp" 'lsp-java-create-parameter
-        "jcf" 'lsp-java-create-field
-        "jcl" 'lsp-java-create-local
-        "jem" 'lsp-java-extract-method
-        "jai" 'lsp-java-add-import
-        "jtb" 'lsp-jt-browser
-        "jro" 'lsp-jt-report-open
-        "jlm" 'lsp-jt-lens-mode)
+      )
 
       ;; Flycheck
       (require 'flycheck)
@@ -229,18 +165,6 @@ in
       (defvar projectile-project-root nil)
       (projectile-mode +1)
 
-      ;; LSP Mode
-      (require 'lsp-mode)
-      (add-hook 'prog-mode-hook #'lsp-deferred)
-
-      (require 'lsp-java)
-      (add-hook 'java-mode-hook #'lsp-deferred)
-      (setq lsp-java-server-install-dir "${pkgs.jdt-language-server}/share/java")
-
-      ;; Enable LSP-UI
-      (require 'lsp-ui)
-      (add-hook 'lsp-mode-hook 'lsp-ui-mode)
-
       ;; Enable Scala
       ;; scala-ts-mode configuration
       (let ((scala-ts-mode-dir "~/.scalaTsMode")
@@ -256,18 +180,6 @@ in
             ;; If there's an error, print a message (you can also log or take other actions)
             (error (message "Failed to load scala-ts-mode: %s" err)))))
 
-
-      (require 'lsp-metals)
-      (add-hook 'scala-ts-hook #'lsp-metals-bootstrapped)
-
-      ;; Enable LSP-TailwindCSS
-      (require 'lsp-tailwindcss)
-      (add-hook 'css-mode-hook #'lsp-deferred)
-
-      ;; (require 'python-mode)
-      ;; (require 'lsp-pyright)
-      ;; (require 'blacken)
-      ;; (add-hook 'python-mode-hook #'lsp-deferred)
 
       ;; Enable SQL
       (require 'sql)
@@ -345,6 +257,18 @@ in
        (scala "https://github.com/tree-sitter/tree-sitter-scala")
       ))
 
+      
+      (dolist (mode
+           '(
+             clojure-mode-hook
+             clojurescript-mode-hook
+             clojurec-mode-hook
+             scala-ts-mode-hook
+             haskell-mode-hook))
+      (add-hook mode 'eglot-ensure))
+
+      (with-eval-after-load 'eglot
+      (add-to-list 'eglot-server-programs '((scala-mode scala-ts-mode) . ("metals"))))
 
       (add-hook 'java-mode-hook #'tree-sitter-mode)
       (add-hook 'java-mode-hook #'tree-sitter-hl-mode)

--- a/home/common/programs/emacs.nix
+++ b/home/common/programs/emacs.nix
@@ -71,13 +71,7 @@ in
         # Programming language packages.
         company # Modular text completion framework
         helm-xref # Helm UI for xref
-        go-mode # Major mode for the Go programming language
-        javap-mode # Major mode for editing Java bytecode
-        java-imports # Automatically import Java classes
-        java-snippets # Yasnippets for Java
-        javadoc-lookup # Lookup Javadoc documentation
         json-mode # Major mode for editing JSON files
-        organize-imports-java # Organize imports for Java
         vue-mode # Major mode for editing Vue.js files
         yaml-mode # Major mode for editing YAML files
         yasnippet # Template system for Emacs
@@ -204,7 +198,6 @@ in
       (require 'json-mode)
       (require 'dap-chrome)
       (add-to-list 'auto-mode-alist '("\\.vue\\'" . vue-mode))
-      (add-hook 'vue-mode-hook #'lsp-deferred)
       (flycheck-add-mode 'javascript-eslint 'web-mode)
 
       ;; Web-mode configurations
@@ -264,17 +257,15 @@ in
              clojurescript-mode-hook
              clojurec-mode-hook
              scala-ts-mode-hook
-             haskell-mode-hook))
+             ))
       (add-hook mode 'eglot-ensure))
 
       (with-eval-after-load 'eglot
       (add-to-list 'eglot-server-programs '((scala-mode scala-ts-mode) . ("metals"))))
 
-      (add-hook 'java-mode-hook #'tree-sitter-mode)
-      (add-hook 'java-mode-hook #'tree-sitter-hl-mode)
-
       (require 'company)
       (setq company-backends '(company-capf))
+      (add-hook 'after-init-hook 'global-company-mode)
 
       ;; Direnv Configuration
       (direnv-mode)


### PR DESCRIPTION
Removes lsp-mode and adds eglot. Changed how copilot is fetched as well as scala-ts-mode, this can be removed once they are added to melpa as nixpkgs emacspkgs tracks melpa. 

Still need to add keybinds for common lsp commands. 